### PR TITLE
Add backend CSP allowing frame-src blob: for downloads (csp)

### DIFF
--- a/Configuration/ContentSecurityPolicies.php
+++ b/Configuration/ContentSecurityPolicies.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Directive;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Mutation;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationCollection;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationMode;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Scope;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\SourceScheme;
+use TYPO3\CMS\Core\Type\Map;
+
+return Map::fromEntries(
+    [
+        Scope::backend(),
+        new MutationCollection(
+            new Mutation(
+                MutationMode::Extend,
+                Directive::FrameSrc,
+                SourceScheme::blob,
+            ),
+        ),
+    ],
+);


### PR DESCRIPTION
This extends existing backend Content-Security-Policy and adds the blob: scheme to allow the download in https://github.com/FriendsOfTYPO3/content-blocks-gui/blob/main/Resources/Public/JavaScript/content-blocks-gui/list.js#L419-L435

Fixes: #5 