### PR TITLE
[FIX] Normalize field identifiers

### DIFF
--- a/Build/Sources/TypeScript/friendsoftypo3/content-blocks-gui/editor/field-identifier.ts
+++ b/Build/Sources/TypeScript/friendsoftypo3/content-blocks-gui/editor/field-identifier.ts
@@ -1,0 +1,16 @@
+/*
+* This file is part of the TYPO3 CMS project.
+*
+* It is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, either version 2
+* of the License, or any later version.
+*
+* For the full copyright and license information, please read the
+* LICENSE.txt file that was distributed with this source code.
+*
+* The TYPO3 project - inspiring people to share!
+*/
+
+export function normalizeFieldIdentifier(identifier: string): string {
+  return identifier.trim().toLowerCase().replace(/\s+/g, '_');
+}

--- a/Build/Sources/TypeScript/friendsoftypo3/content-blocks-gui/editor/right-pane.ts
+++ b/Build/Sources/TypeScript/friendsoftypo3/content-blocks-gui/editor/right-pane.ts
@@ -25,6 +25,7 @@ import '@friendsoftypo3/content-blocks-gui/editor/right-pane-components/slider-s
 import '@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-types.js';
 import '@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-custom-properties.js';
 import '@friendsoftypo3/content-blocks-gui/editor/right-pane-components/items.js';
+import { normalizeFieldIdentifier } from '@friendsoftypo3/content-blocks-gui/editor/field-identifier.js';
 
 /**
  * Module: @typo3/module/web/ContentBlocksGui
@@ -230,7 +231,11 @@ export class ContentBlockEditorRightPane extends LitElement {
   protected dispatchBlurEvent(event: Event): void {
     event.preventDefault();
     const target = event.target as HTMLInputElement;
-    this.values[target.id] = target.type === 'checkbox' ? target.checked : target.value;
+    const value = target.id === 'identifier' && target.tagName === 'INPUT'
+      ? normalizeFieldIdentifier(target.value)
+      : target.value;
+    target.value = value;
+    this.values[target.id] = target.type === 'checkbox' ? target.checked : value;
     this.dispatchEvent(new CustomEvent('updateCbFieldData', {
       bubbles: true,
       composed: true,

--- a/Resources/Public/JavaScript/content-blocks-gui/editor/field-identifier.js
+++ b/Resources/Public/JavaScript/content-blocks-gui/editor/field-identifier.js
@@ -1,0 +1,13 @@
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+function r(e){return e.trim().toLowerCase().replace(/\s+/g,"_")}export{r as normalizeFieldIdentifier};

--- a/Resources/Public/JavaScript/content-blocks-gui/editor/right-pane.js
+++ b/Resources/Public/JavaScript/content-blocks-gui/editor/right-pane.js
@@ -10,7 +10,7 @@
  *
  * The TYPO3 project - inspiring people to share!
  */
-import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,customElement as m}from"lit/decorators.js";import"@typo3/backend/element/icon-element.js";import{live as d}from"lit/directives/live.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/value-picker.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/range-selector.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/slider-selector.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-types.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-custom-properties.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/items.js";var o=function(h,e,t,l){var a=arguments.length,i=a<3?e:l===null?l=Object.getOwnPropertyDescriptor(e,t):l,c;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")i=Reflect.decorate(h,e,t,l);else for(var u=h.length-1;u>=0;u--)(c=h[u])&&(i=(a<3?c(i):a>3?c(e,t,i):c(e,t))||i);return a>3&&i&&Object.defineProperty(e,t,i),i};let n=class extends v{constructor(){super(...arguments),this.parentPath=[]}render(){return this.schema?s`
+import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,customElement as m}from"lit/decorators.js";import"@typo3/backend/element/icon-element.js";import{live as d}from"lit/directives/live.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/value-picker.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/range-selector.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/slider-selector.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-types.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/allowed-custom-properties.js";import"@friendsoftypo3/content-blocks-gui/editor/right-pane-components/items.js";import{normalizeFieldIdentifier as $}from"@friendsoftypo3/content-blocks-gui/editor/field-identifier.js";var o=function(h,e,t,i){var a=arguments.length,l=a<3?e:i===null?i=Object.getOwnPropertyDescriptor(e,t):i,c;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")l=Reflect.decorate(h,e,t,i);else for(var u=h.length-1;u>=0;u--)(c=h[u])&&(l=(a<3?c(l):a>3?c(e,t,l):c(e,t))||l);return a>3&&l&&Object.defineProperty(e,t,l),l};let n=class extends v{constructor(){super(...arguments),this.parentPath=[]}render(){return this.schema?s`
         <div class="content-block-field-configuration">
           <div class="field-properties">
             ${this.schema.properties.map(e=>s` ${this.renderFormFieldset(e)}`)}
@@ -22,7 +22,7 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
           <strong>No field selected</strong><br>
           Please select a field to configure its properties.
         </div>
-      </div>`}renderFormFieldset(e){const t=this.formatFieldLabel(e.name),l=["identifier","type","useExistingField"].includes(e.name),a=e.name==="identifier"&&this.level===0&&this.fieldMetadata&&this.contenttype!=="record-type";return s`
+      </div>`}renderFormFieldset(e){const t=this.formatFieldLabel(e.name),i=["identifier","type","useExistingField"].includes(e.name),a=e.name==="identifier"&&this.level===0&&this.fieldMetadata&&this.contenttype!=="record-type";return s`
       <div class="form-section mb-2">
         <div class="form-section-content">
           ${e.dataType==="boolean"?s`
@@ -34,14 +34,14 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
             <label for="${e.name}" class="form-label">${t}</label>
             ${this.renderFormField(e)}
           `}
-          ${l?this.renderValidationBadge():""}
+          ${i?this.renderValidationBadge():""}
           ${a?this.renderBaseFieldsHelper():""}
         </div>
       </div>`}renderFormField(e){if(e.name==="type"&&this.fieldTypeList)return this.renderTypeDropdown(e);if(e.name==="identifier"&&this.values.type==="Basic"&&this.availableBasics)return this.renderBasicIdentifierDropdown(e);switch(e.dataType){case"text":return s`<input @blur="${this.dispatchBlurEvent}" type="text" id="${e.name}" .value="${d(this.values[e.name]||e.default||"")}" class="form-control" />`;case"number":return s`<input @blur="${this.dispatchBlurEvent}" type="number" id="${e.name}" .value="${d(this.values[e.name]||e.default)}" class="form-control" />`;case"select":const t=e.name==="prefixType"&&this.values.prefixFields===!1;return s`<select @change="${this.dispatchBlurEvent}" class="form-select" id="${e.name}" ?disabled="${t}">
           <option value="">Choose...</option>
-          ${e.items.map(i=>s`
-            <option .value="${d(i.value)}" ?selected="${d(this.values[e.name]===i.value)}">${i.label}</option>`)}
-        </select>`;case"boolean":const l=e.name==="prefixFields"&&this.values._isBaseField,a=l?!1:this.values[e.name]||e.default;return s`<input @change="${this.dispatchBlurEvent}" type="checkbox" id="${e.name}" ?checked=${d(a)} ?disabled="${l}" class="form-check-input" />`;case"textarea":return s`<textarea @blur="${this.dispatchBlurEvent}" id="${e.name}" class="form-control">${d(e.default)}</textarea>`;case"array":switch(e.name){case"valuePicker":return s`<content-block-editor-value-picker
+          ${e.items.map(l=>s`
+            <option .value="${d(l.value)}" ?selected="${d(this.values[e.name]===l.value)}">${l.label}</option>`)}
+        </select>`;case"boolean":const i=e.name==="prefixFields"&&this.values._isBaseField,a=i?!1:this.values[e.name]||e.default;return s`<input @change="${this.dispatchBlurEvent}" type="checkbox" id="${e.name}" ?checked=${d(a)} ?disabled="${i}" class="form-check-input" />`;case"textarea":return s`<textarea @blur="${this.dispatchBlurEvent}" id="${e.name}" class="form-control">${d(e.default)}</textarea>`;case"array":switch(e.name){case"valuePicker":return s`<content-block-editor-value-picker
                   .fieldTypeProperty="${e}"
                   .values="${this.values}"
                   .position="${this.position}"
@@ -83,7 +83,7 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
                   .level="${this.level}"
                   .parentPath="${this.parentPath}"
                   @updateCbFieldData="${this.dispatchUpdateEvent}">
-                </content-block-editor-items>`;default:return s`Array field type for property ${e.name} is not yet implemented.`}default:return s`Unknown field type property ${e.name}.`}}dispatchUpdateEvent(){this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}}))}formatFieldLabel(e){return e.replace(/([A-Z])/g," $1").replace(/^./,t=>t.toUpperCase()).trim()}dispatchBlurEvent(e){e.preventDefault();const t=e.target;this.values[t.id]=t.type==="checkbox"?t.checked:t.value,this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}}))}renderTypeDropdown(e){const t=[...this.fieldTypeList].sort((i,c)=>i.type.localeCompare(c.type)),l=this.values[e.name]||"",a=this.values._isBaseField||!1;return s`
+                </content-block-editor-items>`;default:return s`Array field type for property ${e.name} is not yet implemented.`}default:return s`Unknown field type property ${e.name}.`}}dispatchUpdateEvent(){this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}}))}formatFieldLabel(e){return e.replace(/([A-Z])/g," $1").replace(/^./,t=>t.toUpperCase()).trim()}dispatchBlurEvent(e){e.preventDefault();const t=e.target,i=t.id==="identifier"&&t.tagName==="INPUT"?$(t.value):t.value;t.value=i,this.values[t.id]=t.type==="checkbox"?t.checked:i,this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}}))}renderTypeDropdown(e){const t=[...this.fieldTypeList].sort((l,c)=>l.type.localeCompare(c.type)),i=this.values[e.name]||"",a=this.values._isBaseField||!1;return s`
       <select
         @change="${this.handleTypeChange}"
         class="form-select"
@@ -91,21 +91,21 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
         ?disabled="${a}"
       >
         <option value="">Choose...</option>
-        ${t.map(i=>s`
+        ${t.map(l=>s`
           <option
-            value="${i.type}"
-            ?selected="${l===i.type}"
+            value="${l.type}"
+            ?selected="${i===l.type}"
           >
-            ${i.type}
+            ${l.type}
           </option>
         `)}
       </select>
-    `}handleTypeChange(e){e.preventDefault();const l=e.target.value;this.values.type=l,this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values,typeChanged:!0,newType:l}}))}renderValidationBadge(){const e=this.values._validation;if(!e||!e.message)return p;const t={success:"alert-success",warning:"alert-warning",error:"alert-danger",info:"alert-info"},l={success:"actions-check",warning:"actions-exclamation",error:"actions-close",info:"actions-info"},a=t[e.severity]||"alert-info",i=l[e.severity]||"actions-info";return s`
+    `}handleTypeChange(e){e.preventDefault();const i=e.target.value;this.values.type=i,this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values,typeChanged:!0,newType:i}}))}renderValidationBadge(){const e=this.values._validation;if(!e||!e.message)return p;const t={success:"alert-success",warning:"alert-warning",error:"alert-danger",info:"alert-info"},i={success:"actions-check",warning:"actions-exclamation",error:"actions-close",info:"actions-info"},a=t[e.severity]||"alert-info",l=i[e.severity]||"actions-info";return s`
       <div class="alert ${a} mt-2 mb-0 py-1 px-2 d-flex align-items-center" role="alert">
-        <typo3-backend-icon identifier="${i}" size="small" class="me-1"></typo3-backend-icon>
+        <typo3-backend-icon identifier="${l}" size="small" class="me-1"></typo3-backend-icon>
         <small>${e.message}</small>
       </div>
-    `}renderBaseFieldsHelper(){if(!this.fieldMetadata||!this.fieldMetadata.baseFields)return p;const e=this.fieldMetadata.systemReservedFields||[],t=Array.isArray(e)?e:Object.values(e),l=Object.entries(this.fieldMetadata.baseFields).filter(([a])=>!t.includes(a)).sort(([a],[i])=>a.localeCompare(i));return s`
+    `}renderBaseFieldsHelper(){if(!this.fieldMetadata||!this.fieldMetadata.baseFields)return p;const e=this.fieldMetadata.systemReservedFields||[],t=Array.isArray(e)?e:Object.values(e),i=Object.entries(this.fieldMetadata.baseFields).filter(([a])=>!t.includes(a)).sort(([a],[l])=>a.localeCompare(l));return s`
       <div class="mt-2">
         <label class="form-label text-muted small">Or choose from existing base fields:</label>
         <select
@@ -113,9 +113,9 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
           @change="${this.handleBaseFieldSelection}"
           .value="${""}">
           <option value="">Select a base field...</option>
-          ${l.map(([a,i])=>s`
+          ${i.map(([a,l])=>s`
             <option value="${a}">
-              ${a} (${i.type})
+              ${a} (${l.type})
             </option>
           `)}
         </select>
@@ -123,14 +123,14 @@ import{LitElement as v,html as s,nothing as p}from"lit";import{property as r,cus
           Base fields are reusable TCA columns like header, bodytext, etc.
         </small>
       </div>
-    `}handleBaseFieldSelection(e){const t=e.target,l=t.value;l&&(this.values.identifier=l,this.values.useExistingField=!0,t.value="",this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}})))}renderBasicIdentifierDropdown(e){const t=this.values[e.name]||"",l=[...this.availableBasics||[]].sort((a,i)=>a.identifier.localeCompare(i.identifier));return s`
+    `}handleBaseFieldSelection(e){const t=e.target,i=t.value;i&&(this.values.identifier=i,this.values.useExistingField=!0,t.value="",this.dispatchEvent(new CustomEvent("updateCbFieldData",{bubbles:!0,composed:!0,detail:{position:this.position,level:this.level,parentPath:this.parentPath,values:this.values}})))}renderBasicIdentifierDropdown(e){const t=this.values[e.name]||"",i=[...this.availableBasics||[]].sort((a,l)=>a.identifier.localeCompare(l.identifier));return s`
       <select
         @change="${this.dispatchBlurEvent}"
         class="form-select"
         id="${e.name}"
       >
         <option value="">Choose a Basic...</option>
-        ${l.map(a=>s`
+        ${i.map(a=>s`
           <option
             value="${a.identifier}"
             ?selected="${t===a.identifier}"

--- a/Tests/Playwright/tests/editor.spec.ts
+++ b/Tests/Playwright/tests/editor.spec.ts
@@ -105,6 +105,22 @@ test.describe('Editor', () => {
     await context.close();
   });
 
+  test('field identifiers are trimmed, lowercased, and separated with underscores (#21)', async ({ browser }) => {
+    const context = await createAuthContext(browser);
+    const page = await context.newPage();
+    const frame = await openNewEditor(page);
+
+    expect(await dropFieldType(page, 'Text', 'Text_0')).toBe(true);
+    await page.waitForTimeout(500);
+    await clickField(frame, 'Text_0');
+    await renameActiveField(frame, page, '  Hero   Headline  ');
+
+    await expect(frame.locator('content-block-editor-right-pane #identifier')).toHaveValue('hero_headline');
+    await expectMiddlePaneIdentifier(frame, 'hero_headline', 'Text_0');
+
+    await context.close();
+  });
+
   test('extension dropdown lists destination extensions', async ({ browser }) => {
     const context = await createAuthContext(browser);
     const page = await context.newPage();


### PR DESCRIPTION
## Summary

- normalize manually entered field identifiers when the input loses focus
- trim surrounding whitespace, lowercase the value, and replace whitespace runs with underscores
- leave Basic identifier selections untouched because those values may be case-sensitive
- regenerate the committed JavaScript assets
- add a Playwright regression covering the input and propagated middle-pane identifier

## Root cause

The right-pane blur handler persisted the identifier input verbatim. That allowed labels such as `Hero Headline` to reach the schema unchanged instead of the normalized `hero_headline` form expected by Content Blocks.

The normalization is intentionally limited to the text `input#identifier`; the Basic field path renders a `select#identifier` and must preserve the selected identifier exactly.

## Validation

- targeted ESLint for `right-pane.ts` and `field-identifier.ts`
- generated-helper runtime smoke test for trimming, case conversion, repeated spaces, tabs, and newlines
- `npm run process-js` — processed all 22 TypeScript outputs and regenerated the public assets
- `npx playwright test tests/editor.spec.ts --list` — all 15 tests discovered, including the new regression
- `git diff --check`

The full DDEV-backed Playwright run was not available locally because DDEV/Docker was unavailable. The repository-wide build also currently reports pre-existing lint/type errors outside the changed files; the changed sources pass targeted linting.

Fixes #21
